### PR TITLE
Remove model move to support low mem usage in SPMD-FSDP

### DIFF
--- a/torchacc/dist/spmd_fsdp.py
+++ b/torchacc/dist/spmd_fsdp.py
@@ -65,9 +65,8 @@ class SpmdFullyShardedDataParallel(ParallelModule):
 
         mesh = self._get_mesh((self.mesh.get_fsdp_num(), 1), None,
                               ('fsdp', 'tensor'))
-
         model = FSDPv2(
-            model.to(lazy_device()),
+            model,
             mesh,
             shard_output=self.shard_output_callable,
             auto_wrap_policy=auto_wrap_policy,


### PR DESCRIPTION
In the current implementation of SPMD-FSDP, the model movement is managed by the following code segment regardless of whether low memory usage mode is activated. 

https://github.com/AlibabaPAI/xla/blob/63e20fb8e02243a27fc2486670a85d7b4ab03c1b/torch_xla/experimental/spmd_fully_sharded_data_parallel.py#L100

However, model movement may cause the `materialize_module` to fail under low memory usage.
