### PR TITLE
support save&load of fsdp_optim_state

### DIFF
--- a/tests/distributed/test_fsdp_optim_state.py
+++ b/tests/distributed/test_fsdp_optim_state.py
@@ -31,9 +31,9 @@ class Net(torch.nn.Module):
 
 def _init_model(size, config: Config):
     model = Net(size)
-    model = FSDP(model, config)
+    model = ta.accelerate(model, config=config)
     optim = torch.optim.AdamW(model.parameters(), lr=0.1)
-
+    
     return model, optim
 
 
@@ -43,7 +43,7 @@ def _train(model: torch.nn.Module,
            num_iters: int = 1):
     optim.zero_grad()
     batch_size = model_size
-    device = ta.lazy_device()
+    device = model.device
 
     for i in range(num_iters):
         data = torch.rand(batch_size, model_size).to(device)
@@ -60,7 +60,7 @@ def _train_without_update(model: torch.nn.Module,
     # do forward and backward and no optim.step()
     optim.zero_grad()
     batch_size = model_size
-    device = ta.lazy_device()
+    device = model.device
 
     data = torch.rand(batch_size, model_size).to(device)
     labels = torch.zeros(batch_size, dtype=torch.int64).to(device)
@@ -100,12 +100,15 @@ def _get_fsdp_osd_1(world_size,
                     model_size,
                     full_state_dict: bool = True,
                     rank0_only: bool = True,
-                    flatten: bool = True):
+                    flatten: bool = True,
+                    backend: str = 'lazy'):
     config1 = Config()
     config1.dist.fsdp.size = world_size
     config1.dist.fsdp.flatten_parameters = flatten
+    config1.backend = backend
 
     model_1, optim_1 = _init_model(model_size, config=config1)
+    
     # iter 10 steps
     _train(model_1, optim_1, model_size, 10)
 
@@ -126,18 +129,23 @@ def _get_fsdp_osd_2(world_size,
                     fsdp_osd1,
                     full_state_dict: bool = True,
                     rank0_only: bool = True,
-                    flatten: bool = True):
+                    flatten: bool = True,
+                    backend: str = 'lazy'):
     # init a new model with new world_size
     config2 = Config()
     config2.dist.fsdp.size = world_size
     config2.dist.fsdp.flatten_parameters = flatten
+    #config2.backend = backend
     model_2, optim_2 = _init_model(model_size, config=config2)
 
     if rank not in new_group_rank:
         return
+    
     # model_2 load the optim_state_dict from model_1
-    fsdp_osd_to_load = FSDP.load_optim_state_dict(
-        model_2, fsdp_osd1, rank0_only=rank0_only)
+    print(fsdp_osd1)
+    
+    fsdp_osd_to_load = FSDP.optim_state_dict_to_load(
+        model_2, optim_2, fsdp_osd1, rank0_only=rank0_only)
 
     optim_2.load_state_dict(fsdp_osd_to_load)
     _train_without_update(model_2, optim_2, model_size)
@@ -155,7 +163,7 @@ class FSDPOptimStateTest(MultiProcessTestBase):
     @property
     def world_size(self) -> int:
         return 4
-
+    
     @skip_if_lt_x_gpu(2)
     @init_pg("lazy")
     def test_fsdp4_full_optim_state_rank0_only_flatten(self):
@@ -341,3 +349,4 @@ class FSDPOptimStateTest(MultiProcessTestBase):
             rank0_only=rank0_only)
         _check_optim_state(fsdp_osd1, fsdp_osd2)
         _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+    

--- a/tests/distributed/test_fsdp_optim_state.py
+++ b/tests/distributed/test_fsdp_optim_state.py
@@ -1,0 +1,343 @@
+import copy
+
+import torch
+import torch.distributed as dist
+from utils.distributed import MultiProcessTestBase, init_pg, skip_if_lt_x_gpu
+
+import torchacc as ta
+from torchacc.config import Config
+from torchacc.dist.fsdp import FullyShardedDataParallel as FSDP
+
+
+class Net(torch.nn.Module):
+
+    def __init__(self, size):
+        super().__init__()
+        self.size = size
+        self.fc1 = torch.nn.Linear(size, size)
+        self.fc2 = torch.nn.Linear(size, size)
+        self.fc3 = torch.nn.Linear(size, size)
+        self.fc4 = torch.nn.Linear(size, size)
+        self.fc5 = torch.nn.Linear(size, size)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        x = self.fc3(x)
+        x = self.fc4(x)
+        x = self.fc5(x)
+        return x
+
+
+def _init_model(size, config: Config):
+    model = Net(size)
+    model = FSDP(model, config)
+    optim = torch.optim.AdamW(model.parameters(), lr=0.1)
+
+    return model, optim
+
+
+def _train(model: torch.nn.Module,
+           optim: torch.optim.Optimizer,
+           model_size: int = 1024,
+           num_iters: int = 1):
+    optim.zero_grad()
+    batch_size = model_size
+    device = ta.lazy_device()
+
+    for i in range(num_iters):
+        data = torch.rand(batch_size, model_size).to(device)
+        labels = torch.zeros(batch_size, dtype=torch.int64).to(device)
+        loss = model(data)
+        loss = torch.nn.functional.nll_loss(loss, labels)
+        loss.backward()
+        optim.step()
+
+
+def _train_without_update(model: torch.nn.Module,
+                          optim: torch.optim.Optimizer,
+                          model_size: int = 1024):
+    # do forward and backward and no optim.step()
+    optim.zero_grad()
+    batch_size = model_size
+    device = ta.lazy_device()
+
+    data = torch.rand(batch_size, model_size).to(device)
+    labels = torch.zeros(batch_size, dtype=torch.int64).to(device)
+    loss = model(data)
+    loss = torch.nn.functional.nll_loss(loss, labels)
+    loss.backward()
+
+
+def _check_optim_state(fsdp_osd1, fsdp_osd2):
+    state1 = fsdp_osd1['state']
+    state2 = fsdp_osd2['state']
+
+    assert state1.keys() == state2.keys()
+    for key in state1.keys():
+        dict1 = state1[key]
+        dict2 = state2[key]
+        for state_name in dict1.keys():
+            tensor1 = dict1[state_name]
+            tensor2 = dict2[state_name]
+            assert torch.equal(tensor1, tensor2)
+
+
+def _check_optim_param_groups(fsdp_osd1, fsdp_osd2):
+    param1 = fsdp_osd1['param_groups']
+    param2 = fsdp_osd2['param_groups']
+
+    # the length of param is same to the wrapped layer
+    assert len(param1) == len(param2)
+
+    for (value1, value2) in zip(param1, param2):
+        assert value1.keys() == value2.keys()
+        for key in value1.keys():
+            assert value1[key] == value2[key]
+
+
+def _get_fsdp_osd_1(world_size,
+                    model_size,
+                    full_state_dict: bool = True,
+                    rank0_only: bool = True,
+                    flatten: bool = True):
+    config1 = Config()
+    config1.dist.fsdp.size = world_size
+    config1.dist.fsdp.flatten_parameters = flatten
+
+    model_1, optim_1 = _init_model(model_size, config=config1)
+    # iter 10 steps
+    _train(model_1, optim_1, model_size, 10)
+
+    # get the optim_state_dict for model1
+    if full_state_dict:
+        fsdp_osd1 = FSDP.full_optim_state_dict(
+            model_1, optim_1, rank0_only=rank0_only)
+    else:
+        fsdp_osd1 = FSDP.sharded_optim_state_dict(model_1, optim_1)
+
+    return fsdp_osd1
+
+
+def _get_fsdp_osd_2(world_size,
+                    model_size,
+                    rank,
+                    new_group_rank,
+                    fsdp_osd1,
+                    full_state_dict: bool = True,
+                    rank0_only: bool = True,
+                    flatten: bool = True):
+    # init a new model with new world_size
+    config2 = Config()
+    config2.dist.fsdp.size = world_size
+    config2.dist.fsdp.flatten_parameters = flatten
+    model_2, optim_2 = _init_model(model_size, config=config2)
+
+    if rank not in new_group_rank:
+        return
+    # model_2 load the optim_state_dict from model_1
+    fsdp_osd_to_load = FSDP.load_optim_state_dict(
+        model_2, fsdp_osd1, rank0_only=rank0_only)
+
+    optim_2.load_state_dict(fsdp_osd_to_load)
+    _train_without_update(model_2, optim_2, model_size)
+    if full_state_dict:
+        fsdp_osd2 = FSDP.full_optim_state_dict(
+            model_2, optim_2, rank0_only=rank0_only)
+    else:
+        fsdp_osd2 = FSDP.sharded_optim_state_dict(model_2, optim_2)
+
+    return fsdp_osd2
+
+
+class FSDPOptimStateTest(MultiProcessTestBase):
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_full_optim_state_rank0_only_flatten(self):
+        model_size = 1024
+        fsdp_osd1 = _get_fsdp_osd_1(self.world_size, model_size)
+
+        new_world_size = self.world_size
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(new_world_size, model_size, self.rank,
+                                    new_group_ranks, fsdp_osd1)
+        _check_optim_state(fsdp_osd1, fsdp_osd2)
+        _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_to_2_full_optim_state_rank0_only_flatten(self):
+        model_size = 1024
+        fsdp_osd1 = _get_fsdp_osd_1(self.world_size, model_size)
+        # create new communication group
+        assert self.world_size % 2 == 0
+        new_world_size = self.world_size // 2
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(new_world_size, model_size, self.rank,
+                                    new_group_ranks, fsdp_osd1)
+
+        if self.rank in new_group_ranks:
+            _check_optim_state(fsdp_osd1, fsdp_osd2)
+            _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_full_optim_state_not_rank0_only_flatten(self):
+        rank0_only = False
+        model_size = 1024
+        fsdp_osd1 = _get_fsdp_osd_1(
+            self.world_size, model_size, rank0_only=rank0_only)
+        new_world_size = self.world_size
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(
+            new_world_size,
+            model_size,
+            self.rank,
+            new_group_ranks,
+            fsdp_osd1,
+            rank0_only=rank0_only)
+        _check_optim_state(fsdp_osd1, fsdp_osd2)
+        _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_to_2_full_optim_state_not_rank0_only_flatten(self):
+        rank0_only = False
+        model_size = 1024
+        fsdp_osd1 = _get_fsdp_osd_1(
+            self.world_size, model_size, rank0_only=rank0_only)
+        assert self.world_size % 2 == 0
+        new_world_size = self.world_size // 2
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(
+            new_world_size,
+            model_size,
+            self.rank,
+            new_group_ranks,
+            fsdp_osd1,
+            rank0_only=rank0_only)
+        if self.rank in new_group_ranks:
+            _check_optim_state(fsdp_osd1, fsdp_osd2)
+            _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_full_optim_state_rank0_only_noflatten(self):
+        flatten = False
+        model_size = 1024
+        fsdp_osd1 = _get_fsdp_osd_1(
+            self.world_size, model_size, flatten=flatten)
+        new_world_size = self.world_size
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(
+            new_world_size,
+            model_size,
+            self.rank,
+            new_group_ranks,
+            fsdp_osd1,
+            flatten=flatten)
+        _check_optim_state(fsdp_osd1, fsdp_osd2)
+        _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_to_2_full_optim_state_rank0_only_noflatten(self):
+        flatten = False
+        model_size = 1024
+        fsdp_osd1 = _get_fsdp_osd_1(
+            self.world_size, model_size, flatten=flatten)
+
+        assert self.world_size % 2 == 0
+        new_world_size = self.world_size // 2
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(
+            new_world_size,
+            model_size,
+            self.rank,
+            new_group_ranks,
+            fsdp_osd1,
+            flatten=flatten)
+        if self.rank in new_group_ranks:
+            _check_optim_state(fsdp_osd1, fsdp_osd2)
+            _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_sharded_optim_state(self):
+        full_state_dict = False
+        rank0_only = False
+        model_size = 1024
+        fsdp_osd1 = _get_fsdp_osd_1(
+            self.world_size,
+            model_size,
+            full_state_dict=full_state_dict,
+            rank0_only=rank0_only)
+        new_world_size = self.world_size
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(
+            new_world_size,
+            model_size,
+            self.rank,
+            new_group_ranks,
+            fsdp_osd1,
+            full_state_dict=full_state_dict,
+            rank0_only=rank0_only)
+        fsdp_osd1 = fsdp_osd1['optimizer']
+        fsdp_osd2 = fsdp_osd2['optimizer']
+        _check_optim_state(fsdp_osd1, fsdp_osd2)
+        _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_full_optim_state_pad(self):
+        model_size = 4
+        fsdp_osd1 = _get_fsdp_osd_1(self.world_size, model_size)
+        new_world_size = self.world_size
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(new_world_size, model_size, self.rank,
+                                    new_group_ranks, fsdp_osd1)
+        _check_optim_state(fsdp_osd1, fsdp_osd2)
+        _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_full_optim_state_no_flatten_pad(self):
+        model_size = 4
+        flatten = False
+        fsdp_osd1 = _get_fsdp_osd_1(
+            self.world_size, model_size, flatten=flatten)
+        new_world_size = self.world_size
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(
+            new_world_size,
+            model_size,
+            self.rank,
+            new_group_ranks,
+            fsdp_osd1,
+            flatten=flatten)
+        _check_optim_state(fsdp_osd1, fsdp_osd2)
+        _check_optim_param_groups(fsdp_osd1, fsdp_osd2)
+
+    @skip_if_lt_x_gpu(2)
+    @init_pg("lazy")
+    def test_fsdp4_full_optim_state_rank0_only_pad(self):
+        model_size = 4
+        rank0_only = False
+        fsdp_osd1 = _get_fsdp_osd_1(
+            self.world_size, model_size, rank0_only=rank0_only)
+        new_world_size = self.world_size
+        new_group_ranks = list(range(int(new_world_size)))
+        fsdp_osd2 = _get_fsdp_osd_2(
+            new_world_size,
+            model_size,
+            self.rank,
+            new_group_ranks,
+            fsdp_osd1,
+            rank0_only=rank0_only)
+        _check_optim_state(fsdp_osd1, fsdp_osd2)
+        _check_optim_param_groups(fsdp_osd1, fsdp_osd2)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -9,6 +9,7 @@ function test_standalone() {
     torchrun --nproc_per_node=4 standalone/pipeline.py --pp_num 4 --test_skip
     torchrun --nproc_per_node=4 standalone/ta_accelerate.py --gc
     torchrun --nproc_per_node=4 standalone/consolidate_and_reshard_ckpts.py --fsdp_num 4 --ckpt_dir standalone/ckpt --reshard_num 4
+    torchrun --nproc_per_node=4 standalone/eager_fsdp_optim_ckpt.py --backend eager --fsdp_num 4
     # PyTorch DDP
     torchrun --nproc_per_node=4 standalone/ta_accelerate.py --backend eager
     # PyTorch FSDP

--- a/tests/run_ut.sh
+++ b/tests/run_ut.sh
@@ -8,6 +8,7 @@ function test_unittests() {
     pytest tests/core/test_bucketing_loader.py
     pytest tests/core/test_dynamic.py
     pytest tests/distributed/test_dist_ops.py
+    pytest tests/distributed/test_fsdp_optim_state.py
     pytest tests/ops/test_flash_attn.py
     pytest tests/ops/test_context_parallel.py
 }

--- a/tests/run_ut.sh
+++ b/tests/run_ut.sh
@@ -9,7 +9,7 @@ function test_unittests() {
     pytest tests/core/test_dynamic.py
     pytest tests/distributed/test_dist_ops.py
     pytest tests/distributed/test_fsdp_optim_state.py
-    pytest tests/ops/test_flash_attn.py
+    #pytest tests/ops/test_flash_attn.py
     pytest tests/ops/test_context_parallel.py
 }
 

--- a/tests/run_ut.sh
+++ b/tests/run_ut.sh
@@ -9,7 +9,7 @@ function test_unittests() {
     pytest tests/core/test_dynamic.py
     pytest tests/distributed/test_dist_ops.py
     pytest tests/distributed/test_fsdp_optim_state.py
-    #pytest tests/ops/test_flash_attn.py
+    pytest tests/ops/test_flash_attn.py
     pytest tests/ops/test_context_parallel.py
 }
 

--- a/tests/standalone/eager_fsdp_optim_ckpt.py
+++ b/tests/standalone/eager_fsdp_optim_ckpt.py
@@ -1,0 +1,203 @@
+import argparse
+import os
+
+import torch
+from utils import EchoDataset, set_seed
+
+import torchacc as ta
+from torchacc.dist.fsdp import FullyShardedDataParallel as FSDP
+
+
+class Net(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = torch.nn.Linear(1024, 1024)
+        self.fc2 = torch.nn.Linear(1024, 1024)
+        self.fc3 = torch.nn.Linear(1024, 1024)
+        self.fc4 = torch.nn.Linear(1024, 1024)
+        self.fc5 = torch.nn.Linear(1024, 1024)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        x = self.fc3(x)
+        x = self.fc4(x)
+        x = self.fc5(x)
+        return x
+
+
+def compare_optim_dict(state_dict1, state_dict2, rank):
+    state1 = state_dict1['state']
+    state2 = state_dict2['state']
+    if state1.keys() != state2.keys():
+        print("optimizer state keys are different")
+        return
+
+    difference = False
+    for key in state2.keys():
+        dict1 = state1[key]
+        dict2 = state2[key]
+        for state_name in dict1.keys():
+            tensor1 = dict1[state_name]
+            tensor2 = dict2[state_name]
+
+            if not torch.equal(tensor1, tensor2):
+                print(f"Difference found at state key: {key}-{state_name}")
+                print(f"Tensor 1: {tensor1}")
+                print(f"Tensor 2: {tensor2}")
+                difference = True
+
+    param_list1 = state_dict1['param_groups']
+    param_list2 = state_dict2['param_groups']
+
+    for param1, param2 in zip(param_list1, param_list2):
+        if param1.keys() != param2.keys():
+            print("optimizer param_groups keys are different")
+            return
+
+        for key in param2.keys():
+            if param2[key] != param1[key]:
+                print(f"Difference found at param_group key: {key}")
+                print(f"value 1: {param1[key]}")
+                print(f"value 2: {param2[key]}")
+                difference = True
+
+    if not difference:
+        print(f"The optim dict shard of rank {rank} are same.")
+
+
+def train(args, model, device, train_loader, optimizer):
+    steps_per_print = args.steps_per_print
+    train_steps = args.train_steps * args.gradient_accumulation_steps
+
+    scaler = ta.amp.GradScaler() if args.fp16 else None
+
+    amp_dtype = torch.float16 if args.fp16 else torch.bfloat16
+    amp_enabled = args.fp16 or args.bf16
+    gradient_accumulation_steps = args.gradient_accumulation_steps
+
+    total_loss = torch.tensor(0.0).to(device)
+    global_step = 1
+    for step, data in enumerate(train_loader):
+        with torch.cuda.amp.autocast(
+                enabled=amp_enabled, cache_enabled=True, dtype=amp_dtype):
+            loss = model(data[0])
+            loss = torch.nn.functional.nll_loss(loss, data[1])
+        if scaler is not None:
+            scaler.scale(loss).backward()
+        else:
+            loss.backward()
+        step += 1
+        loss = loss.clone().detach() / gradient_accumulation_steps
+        total_loss += loss
+        if step % gradient_accumulation_steps == 0:
+            if scaler is not None:
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                optimizer.step()
+            optimizer.zero_grad()
+            if ta.dist.local_rank() == 0:
+                if global_step % steps_per_print == 0:
+                    ta.sync()
+                    ta.utils.logger.info(
+                        f"step: {global_step}, loss: {total_loss}")
+            if global_step == train_steps:
+                ta.sync()
+                return
+            global_step += 1
+            total_loss.zero_()
+
+
+def main(args):
+    fsdp_num = args.fsdp_num
+    batch_size = args.batch_size
+    train_steps = args.train_steps * args.gradient_accumulation_steps
+
+    model = Net()
+
+    # set config
+    config = ta.Config()
+    config.backend = args.backend
+    config.compute.fp16 = args.fp16
+    config.compute.bf16 = args.bf16
+
+    config.dist.fsdp.size = fsdp_num
+    config.dist.fsdp.wrap_layer_cls = {"Linear"}
+    config.dist.fsdp.flatten_parameters = True
+
+    # accelerate
+    model = ta.accelerate(model, config=config)
+    device = model.device
+
+    optim = torch.optim.AdamW(model.parameters(), lr=0.001)
+
+    train_loader = EchoDataset(
+        data=[
+            torch.zeros(batch_size, 1024),
+            torch.zeros(batch_size, dtype=torch.int64)
+        ],
+        repeat_count=train_steps)
+
+    train_loader = ta.AsyncLoader(train_loader, device)
+
+    # train model
+    train(args, model, device, train_loader, optim)
+    optim_1 = optim.state_dict()
+
+    # test for full eager optim ckpt.
+    ckpt_dir = "standalone/ckpt"
+    if not os.path.exists(ckpt_dir):
+        os.makedirs(ckpt_dir)
+    optim_save_path = os.path.join(ckpt_dir, "eager_full_optim.pth")
+
+    optim_state_dict = FSDP.full_optim_state_dict(model, optim)
+    if ta.dist.local_rank() == 0:
+        ta.save(optim_state_dict, optim_save_path)
+
+    # load full eager optim ckpts.
+    if ta.dist.local_rank() == 0:
+        optim_state_dict = torch.load(optim_save_path)
+    optim_state_dict = FSDP.optim_state_dict_to_load(model, optim,
+                                                     optim_state_dict)
+    optim.load_state_dict(optim_state_dict)
+
+    # the optim_state_dict of current optim(sharded) should equal to origin state.
+    optim_2 = optim.state_dict()
+    compare_optim_dict(optim_1, optim_2, ta.dist.local_rank())
+
+    # test for sharded eager optim ckpt.
+    sharded_optim = FSDP.sharded_optim_state_dict(model, optim)
+
+    optim_save_path = os.path.join(
+        ckpt_dir, f"rank{ta.dist.rank()}-of-{fsdp_num}-optim.pth")
+
+    ta.dist.rendezvous("saving_optim")
+    ta.save(sharded_optim, optim_save_path, master_only=False)
+    sharded_optim = torch.load(optim_save_path)
+
+    sharded_optim = FSDP.optim_state_dict_to_load(model, optim, sharded_optim)
+    optim.load_state_dict(sharded_optim)
+
+    optim_3 = optim.state_dict()
+
+    compare_optim_dict(optim_1, optim_3, ta.dist.local_rank())
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='TorchAcc eager save and load fsdp ckpts')
+    parser.add_argument('--fsdp_num', type=int, default=1)
+    parser.add_argument('--gradient_accumulation_steps', type=int, default=1)
+    parser.add_argument('--batch_size', type=int, default=2)
+    parser.add_argument('--steps_per_print', type=int, default=1)
+    parser.add_argument('--train_steps', type=int, default=10)
+    parser.add_argument("--fp16", action="store_true", default=False)
+    parser.add_argument("--bf16", action="store_true", default=False)
+    parser.add_argument("--backend", type=str, default="eager")
+
+    args = parser.parse_args()
+
+    set_seed()
+    main(args)

--- a/torchacc/dist/__init__.py
+++ b/torchacc/dist/__init__.py
@@ -110,4 +110,4 @@ def rendezvous(tag, payload=b'', replicas=[]):
     The payloads exchanged by all the other cores, with the payload of core
     ordinal `i` at position `i` in the returned tuple.
   """
-    return xm.rendezvous(payload, replicas or None, tag=tag)
+    return xm.rendezvous(tag, payload, replicas)

--- a/torchacc/dist/distributed_parallel.py
+++ b/torchacc/dist/distributed_parallel.py
@@ -1,8 +1,11 @@
+from typing import Any, Dict
+
 import torch
 
 from torchacc.config import Config
-from torchacc.dist import ParallelModule, DataParallel, FullyShardedDataParallel, PipelineParallel, SpmdFullyShardedDataParallel
-from typing import Any, Dict
+from torchacc.dist import (DataParallel, FullyShardedDataParallel,
+                           ParallelModule, PipelineParallel,
+                           SpmdFullyShardedDataParallel)
 
 
 class DistributedParallel(ParallelModule):
@@ -87,23 +90,20 @@ class DistributedParallel(ParallelModule):
 
         return self.model.sharded_optim_state_dict(self.model, optim)
 
-    def full_optim_state_dict(self,
-                              optim: torch.optim.Optimizer,
-                              **kwargs):
+    def full_optim_state_dict(self, optim: torch.optim.Optimizer, **kwargs):
         if not self.has_fsdp or self.spmd_fsdp:
             raise NotImplementedError(
                 "full_optim_state_dict is only support for FullyShardedDataParallel"
             )
 
-        return self.model.full_optim_state_dict(self.model, optim, kwargs)
+        return self.model.full_optim_state_dict(self.model, optim, **kwargs)
 
-    def optim_state_dict_to_load(self,
-                                 optim,
-                                 optim_state_dict: Dict[str, Any],
+    def optim_state_dict_to_load(self, optim, optim_state_dict: Dict[str, Any],
                                  **kwargs):
         if not self.has_fsdp or self.spmd_fsdp:
             raise NotImplementedError(
                 "optim_state_dict_to_load is only support for FullyShardedDataParallel"
             )
 
-        return self.model.optim_state_dict_to_load(self.model, optim, optim_state_dict, kwargs)
+        return self.model.optim_state_dict_to_load(self.model, optim,
+                                                   optim_state_dict, **kwargs)

--- a/torchacc/dist/distributed_parallel.py
+++ b/torchacc/dist/distributed_parallel.py
@@ -2,7 +2,7 @@ import torch
 
 from torchacc.config import Config
 from torchacc.dist import ParallelModule, DataParallel, FullyShardedDataParallel, PipelineParallel, SpmdFullyShardedDataParallel
-
+from typing import Any, Dict
 
 class DistributedParallel(ParallelModule):
     """Enable different distributed parallel for the model.
@@ -77,3 +77,33 @@ class DistributedParallel(ParallelModule):
                 "forward_backward is only supported for pipeline parallel.")
         assert isinstance(self.model, PipelineParallel)
         return self.model.forward_backward(*args, output_fn=output_fn, **kwargs)
+
+    def sharded_optim_state_dict(self, optim: torch.optim.Optimizer):
+        if not self.has_fsdp or self.spmd_fsdp:
+            raise NotImplementedError(
+                "sharded_optim_state_dict is only support for FullyShardedDataParallel"
+            )
+
+        assert isinstance(self.model, FullyShardedDataParallel)
+        return self.model.sharded_optim_state_dict(self.model, optim)
+
+    def full_optim_state_dict(self,
+                              optim: torch.optim.Optimizer,
+                              rank0_only: bool = True,
+                              cpu_offload: bool = True):
+        if not self.has_fsdp or self.spmd_fsdp:
+            raise NotImplementedError(
+                "full_optim_state_dict is only support for FullyShardedDataParallel"
+            )
+        assert isinstance(self.model, FullyShardedDataParallel)
+        return self.model.full_optim_state_dict(self.model, optim)
+
+    def load_optim_state_dict(self,
+                              optim_state_dict: Dict[str, Any],
+                              rank0_only: bool = True):
+        if not self.has_fsdp or self.spmd_fsdp:
+            raise NotImplementedError(
+                "load_optim_state_dict is only support for FullyShardedDataParallel"
+            )
+        assert isinstance(self.model, FullyShardedDataParallel)
+        return self.model.load_optim_state_dict(self.model, optim_state_dict)

--- a/torchacc/dist/distributed_parallel.py
+++ b/torchacc/dist/distributed_parallel.py
@@ -4,6 +4,7 @@ from torchacc.config import Config
 from torchacc.dist import ParallelModule, DataParallel, FullyShardedDataParallel, PipelineParallel, SpmdFullyShardedDataParallel
 from typing import Any, Dict
 
+
 class DistributedParallel(ParallelModule):
     """Enable different distributed parallel for the model.
 

--- a/torchacc/dist/distributed_parallel.py
+++ b/torchacc/dist/distributed_parallel.py
@@ -85,26 +85,25 @@ class DistributedParallel(ParallelModule):
                 "sharded_optim_state_dict is only support for FullyShardedDataParallel"
             )
 
-        assert isinstance(self.model, FullyShardedDataParallel)
         return self.model.sharded_optim_state_dict(self.model, optim)
 
     def full_optim_state_dict(self,
                               optim: torch.optim.Optimizer,
-                              rank0_only: bool = True,
-                              cpu_offload: bool = True):
+                              **kwargs):
         if not self.has_fsdp or self.spmd_fsdp:
             raise NotImplementedError(
                 "full_optim_state_dict is only support for FullyShardedDataParallel"
             )
-        assert isinstance(self.model, FullyShardedDataParallel)
-        return self.model.full_optim_state_dict(self.model, optim)
 
-    def load_optim_state_dict(self,
-                              optim_state_dict: Dict[str, Any],
-                              rank0_only: bool = True):
+        return self.model.full_optim_state_dict(self.model, optim, kwargs)
+
+    def optim_state_dict_to_load(self,
+                                 optim,
+                                 optim_state_dict: Dict[str, Any],
+                                 **kwargs):
         if not self.has_fsdp or self.spmd_fsdp:
             raise NotImplementedError(
-                "load_optim_state_dict is only support for FullyShardedDataParallel"
+                "optim_state_dict_to_load is only support for FullyShardedDataParallel"
             )
-        assert isinstance(self.model, FullyShardedDataParallel)
-        return self.model.load_optim_state_dict(self.model, optim_state_dict)
+
+        return self.model.optim_state_dict_to_load(self.model, optim, optim_state_dict, kwargs)

--- a/torchacc/dist/distributed_parallel.py
+++ b/torchacc/dist/distributed_parallel.py
@@ -88,7 +88,8 @@ class DistributedParallel(ParallelModule):
                 "sharded_optim_state_dict is only support for FullyShardedDataParallel"
             )
 
-        return self.model.sharded_optim_state_dict(self.model, optim)
+        return FullyShardedDataParallel.sharded_optim_state_dict(
+            self.model, optim)
 
     def full_optim_state_dict(self, optim: torch.optim.Optimizer, **kwargs):
         if not self.has_fsdp or self.spmd_fsdp:
@@ -96,7 +97,8 @@ class DistributedParallel(ParallelModule):
                 "full_optim_state_dict is only support for FullyShardedDataParallel"
             )
 
-        return self.model.full_optim_state_dict(self.model, optim, **kwargs)
+        return FullyShardedDataParallel.full_optim_state_dict(
+            self.model, optim, **kwargs)
 
     def optim_state_dict_to_load(self, optim, optim_state_dict: Dict[str, Any],
                                  **kwargs):
@@ -105,5 +107,5 @@ class DistributedParallel(ParallelModule):
                 "optim_state_dict_to_load is only support for FullyShardedDataParallel"
             )
 
-        return self.model.optim_state_dict_to_load(self.model, optim,
-                                                   optim_state_dict, **kwargs)
+        return FullyShardedDataParallel.optim_state_dict_to_load(
+            self.model, optim, optim_state_dict, **kwargs)

--- a/torchacc/dist/fsdp.py
+++ b/torchacc/dist/fsdp.py
@@ -1,6 +1,8 @@
 import functools
 from types import MethodType
-from typing import Dict, Optional, Set
+from typing import Any, Dict, Optional, Set
+from enum import auto, Enum
+import copy
 
 import torch
 import torch.distributed.fsdp as torch_fsdp
@@ -8,12 +10,13 @@ import torch.fx as fx
 from torch.fx.passes.split_module import split_module
 import torch_xla.distributed.fsdp as xla_fsdp
 
+import torchacc as ta
 from torchacc.config import Config
 from torchacc.dist import ParallelModule
 import torchacc.utils.checkpoint as checkpoint
 import torchacc.utils.trace as trace
 import torchacc.utils.utils as utils
-
+import torchacc.dist.state_dict_utils as state_dict_utils
 
 def split_fsdp_wrap_modules(
         graph_model: fx.GraphModule,
@@ -228,3 +231,253 @@ class FullyShardedDataParallel(ParallelModule):
 
     def forward(self, *args, **kwargs):
         return self.model(*args, **kwargs)
+    
+    @staticmethod
+    def sharded_optim_state_dict(
+        model: torch.nn.Module,
+        optim: torch.optim.Optimizer,
+    ):
+        """
+        Return the optimizer state-dict in its sharded form.
+        
+        Args:
+            model (torch.nn.Module): FSDP model(torchacc or xla) whose parameters were 
+            passed into the optimizer ``optim``.
+            optim (torch.optim.Optimizer): Optimizer for model's
+                parameters.
+
+        Returns:
+            Dict[str, Any]: A :class:`dict` containing the optimizer state for
+            fsdp model. Each rank get the sharded optim state added with shard_metadata.
+        """
+        if not isinstance(
+                model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
+                    model, FullyShardedDataParallel):
+            raise NotImplementedError(
+                "The model must be torchacc or xla FSDP model")
+        assert isinstance(model,
+                          xla_fsdp.XlaFullyShardedDataParallel) or isinstance(
+                              model, FullyShardedDataParallel)
+
+        if isinstance(model, FullyShardedDataParallel):
+            model = model.model
+
+        optimizer = {
+            "optimizer": optim.state_dict(),
+            "shard_metadata": model.get_shard_metadata(),
+        }
+
+        return optimizer
+
+    @staticmethod
+    def full_optim_state_dict(model: torch.nn.Module,
+                              optim: torch.optim.Optimizer,
+                              rank0_only: bool = True,
+                              cpu_offload: bool = True) -> Dict[str, Any]:
+        """Return the full optimizer state-dict.
+
+        Consolidates the full optimizer state on rank 0 and returns it
+        as a :class:`dict` following the convention of
+        :meth:`torch.optim.Optimizer.state_dict`, i.e. with keys ``"state"``
+        and ``"param_groups"``. The flattened parameters in ``FSDP`` modules
+        contained in model are mapped back to their unflattened parameters.
+
+        .. warning:: This needs to be called on all ranks since it uses
+            collective communications. However, if ``rank0_only=True``, then
+            the state dict is only populated on rank 0, and all other ranks
+            return an empty :class:`dict`.
+
+        Args:
+            model (torch.nn.Module): FSDP model(torchacc or xla FSDP) whose parameters were 
+            passed into the optimizer ``optim``.
+            optim (torch.optim.Optimizer): Optimizer for model 's
+                parameters.
+            rank0_only (bool): If ``True``, return the populated :class:`dict`
+                only on rank 0; if ``False``, return it on all ranks. (Default:
+                ``True``)
+            cpu_offload(bool): If ``True``, offload the state-dict to cpu. (Default:
+            ``True``)
+
+        Returns:
+            Dict[str, Any]: A :class:`dict` containing the optimizer state for
+            ``model`` 's original unflattened parameters and including keys
+            "state" and "param_groups" following the convention of
+            :meth:`torch.optim.Optimizer.state_dict`. If ``rank0_only=True``,
+            then nonzero ranks return an :class:`dict` with keys but empty value.
+        """
+        if not isinstance(
+                model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
+                    model, FullyShardedDataParallel):
+            raise NotImplementedError(
+                "The model must be torchacc or xla FSDP model")
+        assert isinstance(model,
+                          xla_fsdp.XlaFullyShardedDataParallel) or isinstance(
+                              model, FullyShardedDataParallel)
+
+        if isinstance(model, FullyShardedDataParallel):
+            model = model.model
+
+        shard_meta_data = model.get_shard_metadata()
+        sharded_optim_state = optim.state_dict()['state']
+        optim_state_param_groups = optim.state_dict()['param_groups']
+        # unflattened and consolidated state_dict
+        consolidate_optim_state_dict: Dict[str, Any] = {
+            'state': {},
+            'param_groups': {}
+        }
+
+        # param_names(2-dim list), param_shapes(2-dim list), param_numel(2-dim list)
+        layer_name_lists, layer_size_lists, layer_numel_lists, _ = state_dict_utils.get_layer_full_info(
+            shard_meta_data, model.state_dict())
+
+        # transform 2-dim list name to 1-dim list name
+        flatten_name_list = [
+            fn for layer_fn in layer_name_lists for fn in layer_fn
+        ]
+        # (rank0_only and self.model.rank == 0) or (not rank0_only)
+        if not rank0_only or model.rank == 0:
+            consolidate_optim_state_dict['param_groups'] = copy.deepcopy(
+                optim_state_param_groups)
+            consolidate_optim_state_dict['param_groups'][0]['params'].clear()
+            for fn in flatten_name_list:
+                consolidate_optim_state_dict['param_groups'][0][
+                    'params'].append(fn)
+
+        unflat_state_dict = {fn: {} for fn in flatten_name_list}
+
+        for idx, layer_state in enumerate(sharded_optim_state.values()):
+            layer_names = layer_name_lists[idx]
+            layer_shapes = layer_size_lists[idx]
+            layer_numels = layer_numel_lists[idx]
+            for state_name, state_params in layer_state.items():
+                tensor_buffer = state_dict_utils.all_gather_state(
+                    state_params, model.sharding_groups, model.all_gather_op)
+                tensor_buffer = state_dict_utils.unpad(
+                    tensor_buffer, layer_numels,
+                    model.world_size * model._shard_size_multiple)
+                orig_params = state_dict_utils.unflatten_params(
+                    tensor_buffer, layer_names, layer_shapes, layer_numels)
+
+                if not rank0_only or model.rank == 0:
+                    for fn, fp in zip(layer_names, orig_params):
+                        if cpu_offload:
+                            ta.mark_step()  # tensor evaluation
+                            unflat_state_dict[fn][state_name] = fp.cpu()
+                        else:
+                            unflat_state_dict[fn][state_name] = fp
+                ta.mark_step()
+        consolidate_optim_state_dict['state'] = unflat_state_dict
+
+        return consolidate_optim_state_dict
+
+    @staticmethod
+    def load_optim_state_dict(model: torch.nn.Module,
+                              optim_state_dict: Dict[str, Any],
+                              rank0_only: bool = True) -> Dict[str, Any]:
+        """
+        Convert an optimizer state-dict so that it can be loaded into the
+        optimizer associated with the FSDP model.
+        We check whether the optim_state_dict is sharded automatically.
+        For shard optim_state_dict, we must set rank0_only to false.
+                
+        Args:
+            model (torch.nn.Module): FSDP model(torchacc or xla) whose parameters were 
+            passed into the optimizer whose state_dict is ``optim_state_dict``.
+            optim_state_dict (Dict[str, Any]): The optimizer states to be loaded.
+            rank0_only: (bool): control whether load state_dict only from
+                rank0 at the begining.(Default: ``True``). If set to True,
+                nonzero ranks should pass None in.
+        
+        Returns:
+            Dict[str, Any]: A :class:`dict` containing the optimizer state for
+            model which is sharded.
+        """
+        if not isinstance(
+                model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
+                    model, FullyShardedDataParallel):
+            raise NotImplementedError(
+                "The model must be torchacc or xla FSDP model")
+        assert isinstance(model,
+                          xla_fsdp.XlaFullyShardedDataParallel) or isinstance(
+                              model, FullyShardedDataParallel)
+
+        if isinstance(model, FullyShardedDataParallel):
+            model = model.model
+
+        shard_meta_data = model.get_shard_metadata()
+
+        if optim_state_dict is None:
+            if not rank0_only or model.rank == 0:
+                raise ValueError('optim_state_dict cannot be None')
+            assert rank0_only and model.rank != 0
+
+        # for shard optim_state_dict, we return directly
+        if optim_state_dict is not None and 'shard_metadata' in optim_state_dict.keys(
+        ):
+            if rank0_only is True:
+                raise NotImplementedError(
+                    "we only support rank0_only = False for loading shard optim_state_dict."
+                )
+            assert rank0_only is False
+
+            # the world size should not change
+            if shard_meta_data['world_size'] != optim_state_dict[
+                    'shard_metadata']['world_size']:
+                raise NotImplementedError(
+                    "the sharded_optim_state_dict is loaded with world_size: "
+                    f"{shard_meta_data['world_size']} but stored with: "
+                    f"{optim_state_dict['shard_metadata']['world_size']}!")
+            assert shard_meta_data['world_size'] == optim_state_dict[
+                'shard_metadata']['world_size']
+            return optim_state_dict['optimizer']
+
+        unflat_optim_state = optim_state_dict
+        flat_optim_state: Dict[str, Any] = {'state': {}, 'param_groups': {}}
+
+        layer_name_lists, layer_size_lists, layer_numel_lists, _ = state_dict_utils.get_layer_full_info(
+            shard_meta_data, model.state_dict())
+
+        if rank0_only:
+            unflat_optim_state = state_dict_utils.broadcast_processed_state(
+                unflat_optim_state, model.rank, model.sharding_groups)
+        unflat_state = unflat_optim_state['state']
+
+        flat_optim_state['param_groups'] = copy.deepcopy(
+            unflat_optim_state['param_groups'])
+
+        for idx, layer_names in enumerate(layer_name_lists):
+            flat_value: Dict[str, Any] = {}
+            # broadcast tensor to other ranks per layer per state
+            for state_name in unflat_state[layer_names[0]].keys():
+                tensor_buffer_list = []
+                # we need the params of a whole layer state to be flatten and shard
+                for name in layer_names:
+                    state_params = unflat_state[name][state_name]
+                    # all ranks have same scalar tensor(step) which has been broadcasted in
+                    # broadcast_processed_state above
+                    if isinstance(state_params,
+                                  torch.Tensor) and state_params.dim() == 0:
+                        flat_value[state_name] = state_params
+                        break
+                    tensor_buffer = unflat_state[name][state_name]
+                    if rank0_only:
+                        tensor_buffer = state_dict_utils.broadcast_state(
+                            state_params, model.xla_device, model.rank,
+                            model.sharding_groups,
+                            model.collective_broadcast_op)
+                    tensor_buffer_list.append(tensor_buffer)
+
+                flat_tensor = state_dict_utils.flatten_tensor_list(
+                    tensor_buffer_list)
+
+                if len(flat_tensor):
+                    flat_value[state_name] = model._get_shard(flat_tensor)
+                ta.mark_step()
+
+            flat_optim_state['state'][idx] = flat_value
+
+        flat_optim_state['param_groups'][0]['params'] = [
+            i for i in range(0, len(flat_optim_state['state'].keys()))
+        ]
+
+        return flat_optim_state

--- a/torchacc/dist/fsdp.py
+++ b/torchacc/dist/fsdp.py
@@ -259,11 +259,11 @@ class FullyShardedDataParallel(ParallelModule):
         """
         # get the inner fsdp model
         # the model passed in maybe wrapped in any of the three type below:
-        # DistributedParallel -> FullyShardedDataParallel -> torch/xla FullyShardedDataParallel
-        if hasattr(model, 'model'):
+        # DistributedParallel(FullyShardedDataParallel(torch/torch_xla FullyShardedDataParallel))
+        if isinstance(model, DistributedParallel):
             model = model.model
-            if hasattr(model, 'model'):
-                model = model.model
+        if isinstance(model, FullyShardedDataParallel):
+            model = model.model
 
         if not isinstance(
                 model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
@@ -334,11 +334,11 @@ class FullyShardedDataParallel(ParallelModule):
         """
         # get the inner fsdp model
         # the model passed in maybe wrapped in any of the three type below:
-        # DistributedParallel -> FullyShardedDataParallel -> torch/xla FullyShardedDataParallel
-        if hasattr(model, 'model'):
+        # DistributedParallel(FullyShardedDataParallel(torch/torch_xla FullyShardedDataParallel))
+        if isinstance(model, DistributedParallel):
             model = model.model
-            if hasattr(model, 'model'):
-                model = model.model
+        if isinstance(model, FullyShardedDataParallel):
+            model = model.model
 
         if not isinstance(
                 model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
@@ -453,11 +453,11 @@ class FullyShardedDataParallel(ParallelModule):
         """
         # get the inner fsdp model
         # the model passed in maybe wrapped in any of the three type below:
-        # DistributedParallel -> FullyShardedDataParallel -> torch/xla FullyShardedDataParallel
-        if hasattr(model, 'model'):
+        # DistributedParallel(FullyShardedDataParallel(torch/torch_xla FullyShardedDataParallel))
+        if isinstance(model, DistributedParallel):
             model = model.model
-            if hasattr(model, 'model'):
-                model = model.model
+        if isinstance(model, FullyShardedDataParallel):
+            model = model.model
 
         if not isinstance(
                 model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(

--- a/torchacc/dist/fsdp.py
+++ b/torchacc/dist/fsdp.py
@@ -22,6 +22,7 @@ import torchacc.utils.utils as utils
 from torchacc.config import Config
 from torchacc.dist import ParallelModule
 
+
 def split_fsdp_wrap_modules(
         graph_model: fx.GraphModule,
         layer_cls: Set[str],

--- a/torchacc/dist/fsdp.py
+++ b/torchacc/dist/fsdp.py
@@ -18,6 +18,7 @@ import torchacc.utils.trace as trace
 import torchacc.utils.utils as utils
 import torchacc.dist.state_dict_utils as state_dict_utils
 
+
 def split_fsdp_wrap_modules(
         graph_model: fx.GraphModule,
         layer_cls: Set[str],
@@ -231,7 +232,7 @@ class FullyShardedDataParallel(ParallelModule):
 
     def forward(self, *args, **kwargs):
         return self.model(*args, **kwargs)
-    
+
     @staticmethod
     def sharded_optim_state_dict(
         model: torch.nn.Module,

--- a/torchacc/dist/fsdp.py
+++ b/torchacc/dist/fsdp.py
@@ -22,7 +22,6 @@ import torchacc.utils.utils as utils
 from torchacc.config import Config
 from torchacc.dist import ParallelModule
 
-
 def split_fsdp_wrap_modules(
         graph_model: fx.GraphModule,
         layer_cls: Set[str],
@@ -260,6 +259,7 @@ class FullyShardedDataParallel(ParallelModule):
         # get the inner fsdp model
         # the model passed in maybe wrapped in any of the three type below:
         # DistributedParallel(FullyShardedDataParallel(torch/torch_xla FullyShardedDataParallel))
+        from torchacc.dist import DistributedParallel
         if isinstance(model, DistributedParallel):
             model = model.model
         if isinstance(model, FullyShardedDataParallel):
@@ -335,6 +335,8 @@ class FullyShardedDataParallel(ParallelModule):
         # get the inner fsdp model
         # the model passed in maybe wrapped in any of the three type below:
         # DistributedParallel(FullyShardedDataParallel(torch/torch_xla FullyShardedDataParallel))
+        from torchacc.dist import DistributedParallel
+
         if isinstance(model, DistributedParallel):
             model = model.model
         if isinstance(model, FullyShardedDataParallel):
@@ -454,6 +456,8 @@ class FullyShardedDataParallel(ParallelModule):
         # get the inner fsdp model
         # the model passed in maybe wrapped in any of the three type below:
         # DistributedParallel(FullyShardedDataParallel(torch/torch_xla FullyShardedDataParallel))
+        from torchacc.dist import DistributedParallel
+
         if isinstance(model, DistributedParallel):
             model = model.model
         if isinstance(model, FullyShardedDataParallel):

--- a/torchacc/dist/fsdp.py
+++ b/torchacc/dist/fsdp.py
@@ -244,7 +244,7 @@ class FullyShardedDataParallel(ParallelModule):
         Return the optimizer state-dict in its sharded form.
         
         Args:
-            model (torch.nn.Module): FSDP model(torchacc or xla) whose parameters were 
+            model (torch.nn.Module): FSDP model(torchacc or torch fsdp model) whose parameters were 
             passed into the optimizer ``optim``.
             optim (torch.optim.Optimizer): Optimizer for model's
                 parameters.
@@ -258,17 +258,18 @@ class FullyShardedDataParallel(ParallelModule):
                 fsdp model.
         """
         # get the inner fsdp model
-        while hasattr(model, 'model'):
+        # the model passed in maybe wrapped in any of the three type below:
+        # DistributedParallel -> FullyShardedDataParallel -> torch/xla FullyShardedDataParallel
+        if hasattr(model, 'model'):
             model = model.model
+            if hasattr(model, 'model'):
+                model = model.model
 
         if not isinstance(
                 model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
                     model, torch_fsdp.FullyShardedDataParallel):
             raise NotImplementedError(
                 "The model must be xla or torch FSDP model")
-        assert isinstance(model,
-                          xla_fsdp.XlaFullyShardedDataParallel) or isinstance(
-                              model, torch_fsdp.FullyShardedDataParallel)
 
         # eager backend, return the sharded state_dict directly.
         if isinstance(model, torch_fsdp.FullyShardedDataParallel):
@@ -308,7 +309,7 @@ class FullyShardedDataParallel(ParallelModule):
         as our method.
         
         Args:
-            model (torch.nn.Module): FSDP model(torchacc or xla FSDP) whose parameters were 
+            model (torch.nn.Module): FSDP model(torchacc or torch FSDP model) whose parameters were 
             passed into the optimizer ``optim``.
             optim (torch.optim.Optimizer): Optimizer for model 's
                 parameters.
@@ -332,17 +333,18 @@ class FullyShardedDataParallel(ParallelModule):
             then nonzero ranks return an :class:`dict` with keys but empty value.
         """
         # get the inner fsdp model
-        while hasattr(model, 'model'):
+        # the model passed in maybe wrapped in any of the three type below:
+        # DistributedParallel -> FullyShardedDataParallel -> torch/xla FullyShardedDataParallel
+        if hasattr(model, 'model'):
             model = model.model
+            if hasattr(model, 'model'):
+                model = model.model
 
         if not isinstance(
                 model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
                     model, torch_fsdp.FullyShardedDataParallel):
             raise NotImplementedError(
                 "The model must be xla or torch FSDP model")
-        assert isinstance(model,
-                          xla_fsdp.XlaFullyShardedDataParallel) or isinstance(
-                              model, torch_fsdp.FullyShardedDataParallel)
 
         rank0_only = kwargs.get('rank0_only', True)
         cpu_offload = kwargs.get('cpu_offload', True)
@@ -433,7 +435,7 @@ class FullyShardedDataParallel(ParallelModule):
         (https://pytorch.org/docs/2.3/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.optim_state_dict_to_load)
         
         Args:
-            model (torch.nn.Module): FSDP model(torchacc or xla) whose parameters were 
+            model (torch.nn.Module): FSDP model(torchacc or torch FSDP model) whose parameters were 
             passed into the optimizer whose state_dict is ``optim_state_dict``.
             optim (torch.optim.Optimizer): Optimizer for model 's parameters.
             optim_state_dict (Dict[str, Any]): The optimizer states to be loaded.
@@ -441,7 +443,7 @@ class FullyShardedDataParallel(ParallelModule):
                 The args below are specified for torchacc fsdp:
                 rank0_only: (bool): control whether load state_dict only from
                     rank0 at the begining.(Default: ``True``). If set to True,
-                    nonzero ranks should pass None in.
+                    nonzero ranks should pass optim_state_dict as None in.
                 
                 for args used for torchacc eager mode, please refer to the docs here: 
                     https://pytorch.org/docs/2.3/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.optim_state_dict_to_load
@@ -450,17 +452,18 @@ class FullyShardedDataParallel(ParallelModule):
             model which is sharded for each rank.
         """
         # get the inner fsdp model
-        while hasattr(model, 'model'):
+        # the model passed in maybe wrapped in any of the three type below:
+        # DistributedParallel -> FullyShardedDataParallel -> torch/xla FullyShardedDataParallel
+        if hasattr(model, 'model'):
             model = model.model
+            if hasattr(model, 'model'):
+                model = model.model
 
         if not isinstance(
                 model, xla_fsdp.XlaFullyShardedDataParallel) and not isinstance(
                     model, torch_fsdp.FullyShardedDataParallel):
             raise NotImplementedError(
-                "The model must be xla or torch FSDP model")
-        assert isinstance(model,
-                          xla_fsdp.XlaFullyShardedDataParallel) or isinstance(
-                              model, torch_fsdp.FullyShardedDataParallel)
+                "The model must be torchacc or torch FSDP model")
 
         rank0_only = kwargs.get('rank0_only', True)
         # eager backend

--- a/torchacc/dist/fsdp.py
+++ b/torchacc/dist/fsdp.py
@@ -275,6 +275,7 @@ class FullyShardedDataParallel(ParallelModule):
             optim_state = {"optimizer": optim.state_dict()}
             return optim_state
 
+        # lazy backend
         optim_state = {
             "optimizer": optim.state_dict(),
             "shard_metadata": model.get_shard_metadata(),

--- a/torchacc/dist/state_dict_utils.py
+++ b/torchacc/dist/state_dict_utils.py
@@ -13,6 +13,7 @@ import torch.nn.functional as F
 from torch.utils._pytree import tree_map_only
 import torch_xla.core.xla_model as xm
 
+
 def _numel(shape):
     numel = 1
     for d in shape:
@@ -149,6 +150,7 @@ def get_layer_full_info(shard_metadata, model_state_dict):
 
     return (layer_name_list, layer_size_list, layer_numel_list, sharded_list)
 
+
 def all_gather_state(state_params, sharding_groups, all_gather_op):
     if state_params.dim() == 0:
         return state_params
@@ -156,6 +158,7 @@ def all_gather_state(state_params, sharding_groups, all_gather_op):
     tensor_buffer = all_gather_op(state_params, groups=sharding_groups)
 
     return tensor_buffer
+
 
 class _PosDimTensorInfo(NamedTuple):
     """
@@ -168,15 +171,18 @@ class _PosDimTensorInfo(NamedTuple):
 
     shape: torch.Size
     dtype: torch.dtype
-    
+
+
 def _setup_gloo_distributed(group):
     if not torch.distributed.is_initialized():
         dist.init_process_group()
     pg = dist.new_group(ranks=group, backend="gloo")
     return pg
 
+
 def _cleanup_gloo_distributed(pg):
     dist.destroy_process_group(pg)
+
 
 def broadcast_processed_state(optim_state: dict[str, Any], rank,
                               sharding_groups):
@@ -212,6 +218,7 @@ def broadcast_processed_state(optim_state: dict[str, Any], rank,
         return optim_state
     else:
         return objects[0]
+
 
 def broadcast_state(state_params, device, rank, sharding_groups,
                     collective_broadcast_op):


### PR DESCRIPTION
What this pr do:
1. suport flatten(including padding before shard) and unflatten full_optim_state_dic save and load and test with ut.
2. support save and load of shard_optim_state_dict.
3. support save and load of full and shard optim_state_dict for torchacc eager mode.

performance:
  | shard_model save | consolidate_shard_model(rank0) | consolidate_model save | get full optim | save full optim | total
-- | -- | -- | -- | -- | -- | --
llama3-8B fsdp=4(cpfs) | 13.93 | 28.92s(read shard model 19.79s) | 27.17s |  45.75s | 52.69s | **2.8min** |
llama3-8B fsdp=8(cpfs) | 8.94s | 30.02(read shard model 19.84s) | 26.19 | 44.95s | 53.76s | **2.7min** |
llama3-70B fsdp=32(cpfs) | 21.34s | 291.2s (read shard model 204.51s) | 234.92s |  400s | 477.38s | **24min** |

</article>
